### PR TITLE
Added Additional ggplot2 Data Visualization Blocks

### DIFF
--- a/src/pages/modules/blockly/blocks.js
+++ b/src/pages/modules/blockly/blocks.js
@@ -67,6 +67,26 @@ import './blocks/visualization/Ggf_histogram_substance';
 import './blocks/visualization/Ggf_point';
 import './blocks/visualization/mosaicplot';
 import './blocks/visualization/pie';
+import './blocks/visualization/geom_bar';
+import './blocks/visualization/geom_boxplot';
+import './blocks/visualization/geom_density';
+import './blocks/visualization/geom_histogram';
+import './blocks/visualization/geom_line';
+import './blocks/visualization/geom_point';
+import './blocks/visualization/geom_smooth';
+import './blocks/visualization/Ggeom_bar';
+import './blocks/visualization/Ggeom_boxplot';
+import './blocks/visualization/Ggeom_density';
+import './blocks/visualization/Ggeom_histogram';
+import './blocks/visualization/Ggeom_line';
+import './blocks/visualization/Ggeom_point';
+import './blocks/visualization/Ggeom_smooth';
+import './blocks/visualization/Gggplot_init';
+import './blocks/visualization/ggplot_init';
+import './blocks/visualization/Glabs';
+import './blocks/visualization/Gtheme_minimal';
+import './blocks/visualization/labs.js';
+import './blocks/visualization/theme_minimal.js';
 
 // Setup R blocks generator
 Blockly.RBlocks = new Blockly.Generator('RBlocks');

--- a/src/pages/modules/blockly/blocks/visualization/Ggeom_bar.js
+++ b/src/pages/modules/blockly/blocks/visualization/Ggeom_bar.js
@@ -1,0 +1,50 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['Ggeom_bar'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_bar(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', stat = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['count', 'count'],
+          ['identity', 'identity'],
+        ]),
+        'STAT'
+      )
+      .appendField(', position = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['stack', 'stack'],
+          ['dodge', 'dodge'],
+          ['fill', 'fill'],
+        ]),
+        'POSITION'
+      )
+      .appendField(', fill = ')
+      .appendField(new Blockly.FieldColour('#000000'), 'FILL')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldNumber(1, 0, 1), 'ALPHA')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a bar geometry layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_bar.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_bar'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var stat = block.getFieldValue('STAT');
+  var position = block.getFieldValue('POSITION');
+  var fill = block.getFieldValue('FILL');
+  var alpha = block.getFieldValue('ALPHA');
+  var code = `geom_bar(aes(x=${x_var}), stat="${stat}", position="${position}", fill="${fill}", alpha=${alpha})\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/Ggeom_boxplot.js
+++ b/src/pages/modules/blockly/blocks/visualization/Ggeom_boxplot.js
@@ -1,0 +1,50 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['Ggeom_boxplot'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_boxplot(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput(''), 'Y_VAR')
+      .appendField(', fill = ')
+      .appendField(new Blockly.FieldColour('#000000'), 'FILL')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldNumber(1, 0, 1), 'ALPHA')
+      .appendField(', outlier.shape = ')
+      .appendField(new Blockly.FieldNumber(16, 0, 25), 'OUTLIER_SHAPE')
+      .appendField(', width = ')
+      .appendField(new Blockly.FieldNumber(0.75, 0, 1), 'WIDTH')
+      .appendField(', position = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['dodge', 'dodge'],
+          ['stack', 'stack'],
+        ]),
+        'POSITION'
+      )
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a boxplot geometry layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_boxplot.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_boxplot'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var fill = block.getFieldValue('FILL');
+  var alpha = block.getFieldValue('ALPHA');
+  var outlier_shape = block.getFieldValue('OUTLIER_SHAPE');
+  var width = block.getFieldValue('WIDTH');
+  var position = block.getFieldValue('POSITION');
+
+  var code = `geom_boxplot(aes(x=${x_var}, y=${y_var}), fill="${fill}", alpha=${alpha}, outlier.shape=${outlier_shape}, width=${width}, position="${position}")\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/Ggeom_density.js
+++ b/src/pages/modules/blockly/blocks/visualization/Ggeom_density.js
@@ -1,0 +1,50 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['Ggeom_density'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_density(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', adjust = ')
+      .appendField(new Blockly.FieldNumber(1, 0.1, 2), 'ADJUST')
+      .appendField(', kernel = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['gaussian', 'gaussian'],
+          ['epanechnikov', 'epanechnikov'],
+          ['rectangular', 'rectangular'],
+          ['triangular', 'triangular'],
+          ['biweight', 'biweight'],
+        ]),
+        'KERNEL'
+      )
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldNumber(0.5, 0, 1), 'ALPHA')
+      .appendField(', fill = ')
+      .appendField(new Blockly.FieldColour('#000000'), 'FILL')
+      .appendField(', size = ')
+      .appendField(new Blockly.FieldNumber(1, 0.1, 5), 'SIZE')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a density plot layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_density.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_density'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var adjust = block.getFieldValue('ADJUST');
+  var kernel = block.getFieldValue('KERNEL');
+  var alpha = block.getFieldValue('ALPHA');
+  var fill = block.getFieldValue('FILL');
+  var size = block.getFieldValue('SIZE');
+
+  var code = `geom_density(aes(x=${x_var}), adjust=${adjust}, kernel="${kernel}", alpha=${alpha}, fill="${fill}", size=${size})\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/Ggeom_histogram.js
+++ b/src/pages/modules/blockly/blocks/visualization/Ggeom_histogram.js
@@ -1,0 +1,54 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['Ggeom_histogram'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_histogram(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', binwidth = ')
+      .appendField(new Blockly.FieldNumber(30), 'BINWIDTH')
+      .appendField(', position = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['stack', 'stack'],
+          ['dodge', 'dodge'],
+          ['fill', 'fill'],
+        ]),
+        'POSITION'
+      )
+      .appendField(', stat = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['count', 'count'],
+          ['density', 'density'],
+        ]),
+        'STAT'
+      )
+      .appendField(', fill = ')
+      .appendField(new Blockly.FieldColour('#000000'), 'FILL')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldNumber(0.5, 0, 1), 'ALPHA')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a histogram layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_histogram.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_histogram'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var binwidth = block.getFieldValue('BINWIDTH');
+  var position = block.getFieldValue('POSITION');
+  var stat = block.getFieldValue('STAT');
+  var fill = block.getFieldValue('FILL');
+  var alpha = block.getFieldValue('ALPHA');
+
+  var code = `geom_histogram(aes(x=${x_var}), binwidth=${binwidth}, position="${position}", stat="${stat}", fill="${fill}", alpha=${alpha})\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/Ggeom_line.js
+++ b/src/pages/modules/blockly/blocks/visualization/Ggeom_line.js
@@ -1,0 +1,49 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['Ggeom_line'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_line(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput(''), 'Y_VAR')
+      .appendField(', linetype = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['solid', 'solid'],
+          ['dashed', 'dashed'],
+          ['dotted', 'dotted'],
+          ['dotdash', 'dotdash'],
+        ]),
+        'LINETYPE'
+      )
+      .appendField(', size = ')
+      .appendField(new Blockly.FieldNumber(1, 0.1, 5), 'SIZE')
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldColour('#000000'), 'COLOR')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldNumber(1, 0, 1), 'ALPHA')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a line geometry layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_line.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_line'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var linetype = block.getFieldValue('LINETYPE');
+  var size = block.getFieldValue('SIZE');
+  var color = block.getFieldValue('COLOR');
+  var alpha = block.getFieldValue('ALPHA');
+
+  var code = `geom_line(aes(x=${x_var}, y=${y_var}), linetype="${linetype}", size=${size}, color="${color}", alpha=${alpha})\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/Ggeom_point.js
+++ b/src/pages/modules/blockly/blocks/visualization/Ggeom_point.js
@@ -1,0 +1,49 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['Ggeom_point'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_point(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput(''), 'Y_VAR')
+      .appendField(', size = ')
+      .appendField(new Blockly.FieldNumber(3, 0.1, 10), 'SIZE')
+      .appendField(', shape = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['circle', '16'],
+          ['triangle', '17'],
+          ['square', '15'],
+          ['diamond', '18'],
+        ]),
+        'SHAPE'
+      )
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldColour('#000000'), 'COLOR')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldNumber(1, 0, 1), 'ALPHA')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a scatter plot layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_point.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_point'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var size = block.getFieldValue('SIZE');
+  var shape = block.getFieldValue('SHAPE');
+  var color = block.getFieldValue('COLOR');
+  var alpha = block.getFieldValue('ALPHA');
+
+  var code = `geom_point(aes(x=${x_var}, y=${y_var}), size=${size}, shape=${shape}, color="${color}", alpha=${alpha})\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/Ggeom_smooth.js
+++ b/src/pages/modules/blockly/blocks/visualization/Ggeom_smooth.js
@@ -1,0 +1,51 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['Ggeom_smooth'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_smooth(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput(''), 'Y_VAR')
+      .appendField(', method = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['loess', 'loess'],
+          ['lm', 'lm'],
+          ['gam', 'gam'],
+        ]),
+        'METHOD'
+      )
+      .appendField(', se = ')
+      .appendField(new Blockly.FieldCheckbox('TRUE'), 'SE')
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldColour('#0000FF'), 'COLOR')
+      .appendField(', size = ')
+      .appendField(new Blockly.FieldNumber(1, 0.1, 5), 'SIZE')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldNumber(0.5, 0, 1), 'ALPHA')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a smoothed line with confidence interval to a ggplot');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_smooth.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_smooth'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var method = block.getFieldValue('METHOD');
+  var se = block.getFieldValue('SE') === 'TRUE';
+  var color = block.getFieldValue('COLOR');
+  var size = block.getFieldValue('SIZE');
+  var alpha = block.getFieldValue('ALPHA');
+
+  var code = `geom_smooth(aes(x=${x_var}, y=${y_var}), method="${method}", se=${se}, color="${color}", size=${size}, alpha=${alpha})\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/Gggplot_init.js
+++ b/src/pages/modules/blockly/blocks/visualization/Gggplot_init.js
@@ -1,0 +1,46 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['Gggplot_init'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('ggplot(')
+      .appendField('data = ')
+      .appendField(new Blockly.FieldTextInput(''), 'DATA')
+      .appendField(', aes(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput(''), 'Y_VAR')
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldTextInput(''), 'COLOR_VAR')
+      .appendField(', fill = ')
+      .appendField(new Blockly.FieldTextInput(''), 'FILL_VAR')
+      .appendField('))');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Initialize a ggplot object with custom data and aesthetics');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/ggplot.html');
+  },
+};
+
+Blockly.JavaScript['Gggplot_init'] = function (block) {
+  var data = block.getFieldValue('DATA');
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var color_var = block.getFieldValue('COLOR_VAR');
+  var fill_var = block.getFieldValue('FILL_VAR');
+
+  var code = `ggplot(${data}, aes(x=${x_var}, y=${y_var}`;
+  if (color_var) {
+    code += `, color=${color_var}`;
+  }
+  if (fill_var) {
+    code += `, fill=${fill_var}`;
+  }
+  code += '))\n';
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/Glabs.js
+++ b/src/pages/modules/blockly/blocks/visualization/Glabs.js
@@ -1,0 +1,49 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['Glabs'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('labs(')
+      .appendField('title = ')
+      .appendField(new Blockly.FieldTextInput(''), 'TITLE')
+      .appendField(', x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_LAB')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput(''), 'Y_LAB')
+      .appendField(', subtitle = ')
+      .appendField(new Blockly.FieldTextInput(''), 'SUBTITLE')
+      .appendField(', caption = ')
+      .appendField(new Blockly.FieldTextInput(''), 'CAPTION')
+      .appendField(', tag = ')
+      .appendField(new Blockly.FieldTextInput(''), 'TAG')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add custom labels to a ggplot');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/labs.html');
+  },
+};
+
+Blockly.JavaScript['Glabs'] = function (block) {
+  var title = block.getFieldValue('TITLE');
+  var x_lab = block.getFieldValue('X_LAB');
+  var y_lab = block.getFieldValue('Y_LAB');
+  var subtitle = block.getFieldValue('SUBTITLE');
+  var caption = block.getFieldValue('CAPTION');
+  var tag = block.getFieldValue('TAG');
+
+  var code = 'labs(';
+  if (title) code += `title="${title}", `;
+  if (x_lab) code += `x="${x_lab}", `;
+  if (y_lab) code += `y="${y_lab}", `;
+  if (subtitle) code += `subtitle="${subtitle}", `;
+  if (caption) code += `caption="${caption}", `;
+  if (tag) code += `tag="${tag}", `;
+  code = code.replace(/,\s*$/, '') + ')\n';
+
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/Gtheme_minimal.js
+++ b/src/pages/modules/blockly/blocks/visualization/Gtheme_minimal.js
@@ -1,0 +1,41 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['Gtheme_minimal'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('theme_minimal(')
+      .appendField('base_size = ')
+      .appendField(new Blockly.FieldTextInput('11'), 'BASE_SIZE')
+      .appendField(', base_line_size = ')
+      .appendField(new Blockly.FieldTextInput('0.5'), 'BASE_LINE_SIZE')
+      .appendField(', base_rect_size = ')
+      .appendField(new Blockly.FieldTextInput('0.5'), 'BASE_RECT_SIZE')
+      .appendField(', base_family = ')
+      .appendField(new Blockly.FieldTextInput(''), 'BASE_FAMILY')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Apply a minimal theme to a ggplot with custom parameters');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/ggtheme.html');
+  },
+};
+
+Blockly.JavaScript['Gtheme_minimal'] = function (block) {
+  var base_size = block.getFieldValue('BASE_SIZE');
+  var base_line_size = block.getFieldValue('BASE_LINE_SIZE');
+  var base_rect_size = block.getFieldValue('BASE_RECT_SIZE');
+  var base_family = block.getFieldValue('BASE_FAMILY');
+
+  var code = 'theme_minimal(';
+  if (base_size) code += `base_size=${base_size}, `;
+  if (base_line_size) code += `base_line_size=${base_line_size}, `;
+  if (base_rect_size) code += `base_rect_size=${base_rect_size}, `;
+  if (base_family) code += `base_family="${base_family}", `;
+  code = code.replace(/,\s*$/, '') + ')\n';
+
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/geom_bar.js
+++ b/src/pages/modules/blockly/blocks/visualization/geom_bar.js
@@ -1,0 +1,67 @@
+import Blockly from 'blockly';
+import { categorical_vars } from '../../constants';
+
+Blockly.Blocks['geom_bar'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_bar(')
+      .appendField('stat = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['count', 'count'],
+          ['identity', 'identity'],
+        ]),
+        'STAT'
+      )
+      .appendField(', position = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['stack', 'stack'],
+          ['dodge', 'dodge'],
+          ['fill', 'fill'],
+        ]),
+        'POSITION'
+      )
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a bar geometry layer to a ggplot');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_bar.html');
+  },
+};
+
+Blockly.JavaScript['geom_bar'] = function (block) {
+  var stat = block.getFieldValue('STAT');
+  var position = block.getFieldValue('POSITION');
+  var code = `geom_bar(stat="${stat}", position="${position}")\n`;
+  return code;
+};
+
+Blockly.Blocks['Ggeom_bar'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_bar(')
+      .appendField('stat = ')
+      .appendField(new Blockly.FieldTextInput('count'), 'STAT')
+      .appendField(', position = ')
+      .appendField(new Blockly.FieldTextInput('stack'), 'POSITION')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a bar geometry layer to a ggplot with custom parameters');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_bar.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_bar'] = function (block) {
+  var stat = block.getFieldValue('STAT');
+  var position = block.getFieldValue('POSITION');
+  var code = `geom_bar(stat="${stat}", position="${position}")\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/geom_boxplot.js
+++ b/src/pages/modules/blockly/blocks/visualization/geom_boxplot.js
@@ -1,0 +1,66 @@
+import Blockly from 'blockly';
+import { quantitative_vars, categorical_vars } from '../../constants';
+
+Blockly.Blocks['geom_boxplot'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_boxplot(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldDropdown(categorical_vars), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'Y_VAR')
+      .appendField(', outlier.shape = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['dot', '16'],
+          ['none', 'NA'],
+        ]),
+        'OUTLIER'
+      )
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a boxplot geometry layer to a ggplot');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_boxplot.html');
+  },
+};
+
+Blockly.JavaScript['geom_boxplot'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var outlier = block.getFieldValue('OUTLIER');
+  var code = `geom_boxplot(aes(x=${x_var}, y=${y_var}), outlier.shape=${outlier})\n`;
+  return code;
+};
+
+Blockly.Blocks['Ggeom_boxplot'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_boxplot(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput(''), 'Y_VAR')
+      .appendField(', outlier.shape = ')
+      .appendField(new Blockly.FieldTextInput('16'), 'OUTLIER')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a boxplot geometry layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_boxplot.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_boxplot'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var outlier = block.getFieldValue('OUTLIER');
+  var code = `geom_boxplot(aes(x=${x_var}, y=${y_var}), outlier.shape=${outlier})\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/geom_density.js
+++ b/src/pages/modules/blockly/blocks/visualization/geom_density.js
@@ -1,0 +1,66 @@
+import Blockly from 'blockly';
+import { quantitative_vars } from '../../constants';
+
+Blockly.Blocks['geom_density'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_density(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'X_VAR')
+      .appendField(', adjust = ')
+      .appendField(new Blockly.FieldNumber(1, 0.1, 2), 'ADJUST')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldNumber(0.5, 0, 1), 'ALPHA')
+      .appendField(', fill = ')
+      .appendField(new Blockly.FieldColour('#000000'), 'FILL')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a density plot layer to a ggplot');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_density.html');
+  },
+};
+
+Blockly.JavaScript['geom_density'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var adjust = block.getFieldValue('ADJUST');
+  var alpha = block.getFieldValue('ALPHA');
+  var fill = block.getFieldValue('FILL');
+  var code = `geom_density(aes(x=${x_var}), adjust=${adjust}, alpha=${alpha}, fill="${fill}")\n`;
+  return code;
+};
+
+Blockly.Blocks['Ggeom_density'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_density(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', adjust = ')
+      .appendField(new Blockly.FieldTextInput('1'), 'ADJUST')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldTextInput('0.5'), 'ALPHA')
+      .appendField(', fill = ')
+      .appendField(new Blockly.FieldTextInput('black'), 'FILL')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a density plot layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_density.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_density'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var adjust = block.getFieldValue('ADJUST');
+  var alpha = block.getFieldValue('ALPHA');
+  var fill = block.getFieldValue('FILL');
+  var code = `geom_density(aes(x=${x_var}), adjust=${adjust}, alpha=${alpha}, fill="${fill}")\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/geom_histogram.js
+++ b/src/pages/modules/blockly/blocks/visualization/geom_histogram.js
@@ -1,0 +1,78 @@
+import Blockly from 'blockly';
+import { quantitative_vars } from '../../constants';
+
+Blockly.Blocks['geom_histogram'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_histogram(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'X_VAR')
+      .appendField(', binwidth = ')
+      .appendField(new Blockly.FieldNumber(30), 'BINWIDTH')
+      .appendField(', stat = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['count', 'count'],
+          ['density', 'density'],
+        ]),
+        'STAT'
+      )
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldNumber(0.5, 0, 1), 'ALPHA')
+      .appendField(', fill = ')
+      .appendField(new Blockly.FieldColour('#000000'), 'FILL')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a histogram layer to a ggplot');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_histogram.html');
+  },
+};
+
+Blockly.JavaScript['geom_histogram'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var binwidth = block.getFieldValue('BINWIDTH');
+  var stat = block.getFieldValue('STAT');
+  var alpha = block.getFieldValue('ALPHA');
+  var fill = block.getFieldValue('FILL');
+  var code = `geom_histogram(aes(x=${x_var}), binwidth=${binwidth}, stat="${stat}", alpha=${alpha}, fill="${fill}")\n`;
+  return code;
+};
+
+Blockly.Blocks['Ggeom_histogram'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_histogram(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', binwidth = ')
+      .appendField(new Blockly.FieldTextInput('30'), 'BINWIDTH')
+      .appendField(', stat = ')
+      .appendField(new Blockly.FieldTextInput('count'), 'STAT')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldTextInput('0.5'), 'ALPHA')
+      .appendField(', fill = ')
+      .appendField(new Blockly.FieldTextInput('black'), 'FILL')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a histogram layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_histogram.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_histogram'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var binwidth = block.getFieldValue('BINWIDTH');
+  var stat = block.getFieldValue('STAT');
+  var alpha = block.getFieldValue('ALPHA');
+  var fill = block.getFieldValue('FILL');
+  var code = `geom_histogram(aes(x=${x_var}), binwidth=${binwidth}, stat="${stat}", alpha=${alpha}, fill="${fill}")\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/geom_line.js
+++ b/src/pages/modules/blockly/blocks/visualization/geom_line.js
@@ -1,0 +1,85 @@
+import Blockly from 'blockly';
+import { quantitative_vars } from '../../constants';
+
+Blockly.Blocks['geom_line'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_line(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'Y_VAR')
+      .appendField(', linetype = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['solid', 'solid'],
+          ['dashed', 'dashed'],
+          ['dotted', 'dotted'],
+        ]),
+        'LINETYPE'
+      )
+      .appendField(', size = ')
+      .appendField(new Blockly.FieldNumber(1, 0.1, 5), 'SIZE')
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldColour('#000000'), 'COLOR')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldNumber(1, 0, 1), 'ALPHA')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a line geometry layer to a ggplot');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_line.html');
+  },
+};
+
+Blockly.JavaScript['geom_line'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var linetype = block.getFieldValue('LINETYPE');
+  var size = block.getFieldValue('SIZE');
+  var color = block.getFieldValue('COLOR');
+  var alpha = block.getFieldValue('ALPHA');
+  var code = `geom_line(aes(x=${x_var}, y=${y_var}), linetype="${linetype}", size=${size}, color="${color}", alpha=${alpha})\n`;
+  return code;
+};
+
+Blockly.Blocks['Ggeom_line'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_line(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput(''), 'Y_VAR')
+      .appendField(', linetype = ')
+      .appendField(new Blockly.FieldTextInput('solid'), 'LINETYPE')
+      .appendField(', size = ')
+      .appendField(new Blockly.FieldTextInput('1'), 'SIZE')
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldTextInput('black'), 'COLOR')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldTextInput('1'), 'ALPHA')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a line geometry layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_line.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_line'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var linetype = block.getFieldValue('LINETYPE');
+  var size = block.getFieldValue('SIZE');
+  var color = block.getFieldValue('COLOR');
+  var alpha = block.getFieldValue('ALPHA');
+  var code = `geom_line(aes(x=${x_var}, y=${y_var}), linetype="${linetype}", size=${size}, color="${color}", alpha=${alpha})\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/geom_point.js
+++ b/src/pages/modules/blockly/blocks/visualization/geom_point.js
@@ -1,0 +1,86 @@
+import Blockly from 'blockly';
+import { quantitative_vars } from '../../constants';
+
+Blockly.Blocks['geom_point'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_point(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'Y_VAR')
+      .appendField(', size = ')
+      .appendField(new Blockly.FieldNumber(3, 0.1, 10), 'SIZE')
+      .appendField(', shape = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['circle', '16'],
+          ['triangle', '17'],
+          ['square', '15'],
+          ['diamond', '18'],
+        ]),
+        'SHAPE'
+      )
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldColour('#000000'), 'COLOR')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldNumber(1, 0, 1), 'ALPHA')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a scatter plot layer to a ggplot');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_point.html');
+  },
+};
+
+Blockly.JavaScript['geom_point'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var size = block.getFieldValue('SIZE');
+  var shape = block.getFieldValue('SHAPE');
+  var color = block.getFieldValue('COLOR');
+  var alpha = block.getFieldValue('ALPHA');
+  var code = `geom_point(aes(x=${x_var}, y=${y_var}), size=${size}, shape=${shape}, color="${color}", alpha=${alpha})\n`;
+  return code;
+};
+
+Blockly.Blocks['Ggeom_point'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_point(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput(''), 'Y_VAR')
+      .appendField(', size = ')
+      .appendField(new Blockly.FieldTextInput('3'), 'SIZE')
+      .appendField(', shape = ')
+      .appendField(new Blockly.FieldTextInput('16'), 'SHAPE')
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldTextInput('black'), 'COLOR')
+      .appendField(', alpha = ')
+      .appendField(new Blockly.FieldTextInput('1'), 'ALPHA')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a scatter plot layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_point.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_point'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var size = block.getFieldValue('SIZE');
+  var shape = block.getFieldValue('SHAPE');
+  var color = block.getFieldValue('COLOR');
+  var alpha = block.getFieldValue('ALPHA');
+  var code = `geom_point(aes(x=${x_var}, y=${y_var}), size=${size}, shape=${shape}, color="${color}", alpha=${alpha})\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/geom_smooth.js
+++ b/src/pages/modules/blockly/blocks/visualization/geom_smooth.js
@@ -1,0 +1,85 @@
+import Blockly from 'blockly';
+import { quantitative_vars } from '../../constants';
+
+Blockly.Blocks['geom_smooth'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_smooth(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldDropdown(quantitative_vars), 'Y_VAR')
+      .appendField(', method = ')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['loess', 'loess'],
+          ['lm', 'lm'],
+          ['gam', 'gam'],
+        ]),
+        'METHOD'
+      )
+      .appendField(', se = ')
+      .appendField(new Blockly.FieldCheckbox('TRUE'), 'SE')
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldColour('#0000FF'), 'COLOR')
+      .appendField(', size = ')
+      .appendField(new Blockly.FieldNumber(1, 0.1, 5), 'SIZE')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a smoothed conditional mean layer to a ggplot');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_smooth.html');
+  },
+};
+
+Blockly.JavaScript['geom_smooth'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var method = block.getFieldValue('METHOD');
+  var se = block.getFieldValue('SE') === 'TRUE';
+  var color = block.getFieldValue('COLOR');
+  var size = block.getFieldValue('SIZE');
+  var code = `geom_smooth(aes(x=${x_var}, y=${y_var}), method="${method}", se=${se}, color="${color}", size=${size})\n`;
+  return code;
+};
+
+Blockly.Blocks['Ggeom_smooth'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('geom_smooth(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput(''), 'Y_VAR')
+      .appendField(', method = ')
+      .appendField(new Blockly.FieldTextInput('loess'), 'METHOD')
+      .appendField(', se = ')
+      .appendField(new Blockly.FieldTextInput('TRUE'), 'SE')
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldTextInput('blue'), 'COLOR')
+      .appendField(', size = ')
+      .appendField(new Blockly.FieldTextInput('1'), 'SIZE')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add a smoothed conditional mean layer to a ggplot with custom variables');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/geom_smooth.html');
+  },
+};
+
+Blockly.JavaScript['Ggeom_smooth'] = function (block) {
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var method = block.getFieldValue('METHOD');
+  var se = block.getFieldValue('SE');
+  var color = block.getFieldValue('COLOR');
+  var size = block.getFieldValue('SIZE');
+  var code = `geom_smooth(aes(x=${x_var}, y=${y_var}), method="${method}", se=${se}, color="${color}", size=${size})\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/ggplot_init.js
+++ b/src/pages/modules/blockly/blocks/visualization/ggplot_init.js
@@ -1,0 +1,78 @@
+import Blockly from 'blockly';
+import { quantitative_vars, categorical_vars } from '../../constants';
+
+Blockly.Blocks['ggplot_init'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('ggplot(')
+      .appendField('data = ')
+      .appendField(new Blockly.FieldDropdown([['HELPrct', 'HELPrct']]), 'DATA')
+      .appendField(', aes(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldDropdown([...quantitative_vars, ...categorical_vars]), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldDropdown([...quantitative_vars, ...categorical_vars]), 'Y_VAR')
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldDropdown([['none', 'none'], ...categorical_vars]), 'COLOR_VAR')
+      .appendField('))');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Initialize a ggplot object with data and aesthetics');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/ggplot.html');
+  },
+};
+
+Blockly.JavaScript['ggplot_init'] = function (block) {
+  var data = block.getFieldValue('DATA');
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var color_var = block.getFieldValue('COLOR_VAR');
+
+  var code = `ggplot(${data}, aes(x=${x_var}, y=${y_var}`;
+  if (color_var !== 'none') {
+    code += `, color=${color_var}`;
+  }
+  code += '))\n';
+  return code;
+};
+
+Blockly.Blocks['Gggplot_init'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('ggplot(')
+      .appendField('data = ')
+      .appendField(new Blockly.FieldTextInput(''), 'DATA')
+      .appendField(', aes(')
+      .appendField('x = ')
+      .appendField(new Blockly.FieldTextInput(''), 'X_VAR')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput(''), 'Y_VAR')
+      .appendField(', color = ')
+      .appendField(new Blockly.FieldTextInput(''), 'COLOR_VAR')
+      .appendField('))');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Initialize a ggplot object with custom data and aesthetics');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/ggplot.html');
+  },
+};
+
+Blockly.JavaScript['Gggplot_init'] = function (block) {
+  var data = block.getFieldValue('DATA');
+  var x_var = block.getFieldValue('X_VAR');
+  var y_var = block.getFieldValue('Y_VAR');
+  var color_var = block.getFieldValue('COLOR_VAR');
+
+  var code = `ggplot(${data}, aes(x=${x_var}, y=${y_var}`;
+  if (color_var) {
+    code += `, color=${color_var}`;
+  }
+  code += '))\n';
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/labs.js
+++ b/src/pages/modules/blockly/blocks/visualization/labs.js
@@ -1,0 +1,49 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['labs'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('labs(')
+      .appendField('title = ')
+      .appendField(new Blockly.FieldTextInput('Plot Title'), 'TITLE')
+      .appendField(', x = ')
+      .appendField(new Blockly.FieldTextInput('X Label'), 'X_LAB')
+      .appendField(', y = ')
+      .appendField(new Blockly.FieldTextInput('Y Label'), 'Y_LAB')
+      .appendField(', subtitle = ')
+      .appendField(new Blockly.FieldTextInput(''), 'SUBTITLE')
+      .appendField(', caption = ')
+      .appendField(new Blockly.FieldTextInput(''), 'CAPTION')
+      .appendField(', tag = ')
+      .appendField(new Blockly.FieldTextInput(''), 'TAG')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Add labels to a ggplot');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/labs.html');
+  },
+};
+
+Blockly.JavaScript['labs'] = function (block) {
+  var title = block.getFieldValue('TITLE');
+  var x_lab = block.getFieldValue('X_LAB');
+  var y_lab = block.getFieldValue('Y_LAB');
+  var subtitle = block.getFieldValue('SUBTITLE');
+  var caption = block.getFieldValue('CAPTION');
+  var tag = block.getFieldValue('TAG');
+
+  var code = 'labs(';
+  if (title) code += `title="${title}", `;
+  if (x_lab) code += `x="${x_lab}", `;
+  if (y_lab) code += `y="${y_lab}", `;
+  if (subtitle) code += `subtitle="${subtitle}", `;
+  if (caption) code += `caption="${caption}", `;
+  if (tag) code += `tag="${tag}", `;
+  code = code.replace(/,\s*$/, '') + ')\n';
+
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/blockly/blocks/visualization/theme_minimal.js
+++ b/src/pages/modules/blockly/blocks/visualization/theme_minimal.js
@@ -1,0 +1,28 @@
+import Blockly from 'blockly';
+
+Blockly.Blocks['theme_minimal'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('theme_minimal(')
+      .appendField('base_size = ')
+      .appendField(new Blockly.FieldNumber(11, 6, 24), 'BASE_SIZE')
+      .appendField(', base_line_size = ')
+      .appendField(new Blockly.FieldNumber(0.5, 0.1, 2), 'BASE_LINE_SIZE')
+      .appendField(')');
+    this.setInputsInline(false);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(120);
+    this.setTooltip('Apply a minimal theme to a ggplot');
+    this.setHelpUrl('https://ggplot2.tidyverse.org/reference/ggtheme.html');
+  },
+};
+
+Blockly.JavaScript['theme_minimal'] = function (block) {
+  var base_size = block.getFieldValue('BASE_SIZE');
+  var base_line_size = block.getFieldValue('BASE_LINE_SIZE');
+  var code = `theme_minimal(base_size=${base_size}, base_line_size=${base_line_size})\n`;
+  return code;
+};
+
+export default {};

--- a/src/pages/modules/workspace.js
+++ b/src/pages/modules/workspace.js
@@ -258,6 +258,46 @@ export default function Workspace() {
             kind: 'block',
             type: 'gf_point',
           },
+          {
+            kind: 'block',
+            type: 'ggplot_init',
+          },
+          {
+            kind: 'block',
+            type: 'geom_point',
+          },
+          {
+            kind: 'block',
+            type: 'geom_line',
+          },
+          {
+            kind: 'block',
+            type: 'geom_smooth',
+          },
+          {
+            kind: 'block',
+            type: 'geom_bar',
+          },
+          {
+            kind: 'block',
+            type: 'geom_boxplot',
+          },
+          {
+            kind: 'block',
+            type: 'geom_histogram',
+          },
+          {
+            kind: 'block',
+            type: 'geom_density',
+          },
+          {
+            kind: 'block',
+            type: 'theme_minimal',
+          },
+          {
+            kind: 'block',
+            type: 'labs',
+          },
         ],
       },
       {
@@ -312,6 +352,46 @@ export default function Workspace() {
           {
             kind: 'block',
             type: 'Ggf_point',
+          },
+          {
+            kind: 'block',
+            type: 'Gggplot_init',
+          },
+          {
+            kind: 'block',
+            type: 'Ggeom_point',
+          },
+          {
+            kind: 'block',
+            type: 'Ggeom_line',
+          },
+          {
+            kind: 'block',
+            type: 'Ggeom_smooth',
+          },
+          {
+            kind: 'block',
+            type: 'Ggeom_bar',
+          },
+          {
+            kind: 'block',
+            type: 'Ggeom_boxplot',
+          },
+          {
+            kind: 'block',
+            type: 'Ggeom_histogram',
+          },
+          {
+            kind: 'block',
+            type: 'Ggeom_density',
+          },
+          {
+            kind: 'block',
+            type: 'Gtheme_minimal',
+          },
+          {
+            kind: 'block',
+            type: 'Glabs',
           },
         ],
       },


### PR DESCRIPTION
Addresses #9 

This pull request introduces several new visualization blocks for the Blockly library to support various ggplot2 geometries. These changes enhance the capabilities of the visualization module by adding new blocks for different types of plots and their configurations.

### New Visualization Blocks:

* [`src/pages/modules/blockly/blocks/visualization/Ggeom_bar.js`](diffhunk://#diff-a4eb11ec71ac5932ae1a1f18baa79eea38403f726fcee6ad65539c2829526091R1-R50): Added a block for `geom_bar` to create bar charts with customizable parameters such as `x`, `stat`, `position`, `fill`, and `alpha`.
* [`src/pages/modules/blockly/blocks/visualization/Ggeom_boxplot.js`](diffhunk://#diff-47d5aaf141eba793f19784dbefad44f7b8df910fd346a7ab993607b10d22cdb5R1-R50): Introduced a block for `geom_boxplot` to create boxplots with customizable parameters including `x`, `y`, `fill`, `alpha`, `outlier.shape`, `width`, and `position`.
* [`src/pages/modules/blockly/blocks/visualization/Ggeom_density.js`](diffhunk://#diff-92fb3e1ea75436dc536c7de0adf07ab837c54477795bbd174edf225291d0e908R1-R50): Added a block for `geom_density` to create density plots with parameters like `x`, `adjust`, `kernel`, `alpha`, `fill`, and `size`.
* [`src/pages/modules/blockly/blocks/visualization/Ggeom_histogram.js`](diffhunk://#diff-4b435ae5a53457f6160198b63ffc7979a9d78fe0f2e6bc737e4e68b33cf3749aR1-R54): Introduced a block for `geom_histogram` to create histograms with customizable parameters such as `x`, `binwidth`, `position`, `stat`, `fill`, and `alpha`.
* [`src/pages/modules/blockly/blocks/visualization/Ggeom_line.js`](diffhunk://#diff-20e8fd9bceb6bfa4fed7e293fed3208e96fd0c3c97bd324547f315f4e79abddcR1-R49): Added a block for `geom_line` to create line plots with parameters including `x`, `y`, `linetype`, `size`, `color`, and `alpha`.

### Initialization and Labeling:

* [`src/pages/modules/blockly/blocks/visualization/Gggplot_init.js`](diffhunk://#diff-3a26c17ce376ec59bd0394b71f95a9b68df67cc5ae0d4fc3dbd40d97da783892R1-R46): Added a block for initializing `ggplot` objects with custom data and aesthetics such as `x`, `y`, `color`, and `fill`.
* [`src/pages/modules/blockly/blocks/visualization/Glabs.js`](diffhunk://#diff-ce85437489039814522ed229ae6ee5dd1ddfd65cbc85522b447b2f957079d37dR1-R49): Introduced a block for `labs` to add custom labels to a ggplot, including `title`, `x`, `y`, `subtitle`, `caption`, and `tag`.

### Theming:

* [`src/pages/modules/blockly/blocks/visualization/Gtheme_minimal.js`](diffhunk://#diff-0efdddb160127fb7120b0b23a04a2aa3b629b364c04728aa84e08916f3265bc2R1-R41): Added a block for `theme_minimal` to apply a minimal theme to a ggplot with parameters like `base_size`, `base_line_size`, `base_rect_size`, and `base_family`.

### Import Statements:

* [`src/pages/modules/blockly/blocks.js`](diffhunk://#diff-055ebb7cdd2ed05a44396a2e495d538c1e6688b84edd4e5b69d63c22804f7198R70-R89): Updated import statements to include the newly added visualization blocks.